### PR TITLE
added -C / --sshconfig option.  If provided without a value it defaul…

### DIFF
--- a/sshpt/SSHQueue.py
+++ b/sshpt/SSHQueue.py
@@ -183,7 +183,7 @@ class SSHThread(GenericThread):
         if local_filepath:
             logger.info("sudo: %s, local_filepath: %s, remote_filepath: %s", sudo, local_filepath, remote_filepath)
             local_short_filename = os.path.basename(local_filepath)
-            remote_fullpath = os.path.join(remote_filepath + '/', local_short_filename)
+            remote_fullpath = os.path.join(remote_filepath, local_short_filename)
             try:
                 if sudo:
                     temp_path = os.path.join('/tmp/', local_short_filename)
@@ -207,18 +207,16 @@ class SSHThread(GenericThread):
                 # Make sure the error is included in the command output
                 command_output.append(str(details))
         try:
-            remove = False
             if commands:
                 for command in commands:
                     # This makes a list of lists (each line of output in command_output is it's own item in the list)
                     command_output.append(self.executeCommand(ssh=ssh, command=command, sudo=sudo, password=password))
-                    remove = True
             if local_filepath is False and commands is False and execute is False:
                 # If we're not given anything to execute run the uptime command to make sure that we can execute *something*
                 command_output = self.executeCommand(ssh=ssh, command='uptime', sudo=sudo, password=password)
             if local_filepath and remove:
                 # Clean up/remove the file we just uploaded and executed
-                rm_command = "rm -f %s" % remote_fullpath
+                rm_command = f"rm -f {remote_fullpath}"
                 self.executeCommand(ssh=ssh, command=rm_command, sudo=sudo, password=password)
             command_output = [normalizeString(output) for output in command_output]
         except Exception as detail:

--- a/sshpt/main.py
+++ b/sshpt/main.py
@@ -30,7 +30,6 @@ else:
     from configparser import SafeConfigParser
 from argparse import ArgumentParser
 import logging
-logging.basicConfig(level=logging.INFO)
 
 from . import version
 from .sshpt import SSHPowerTool
@@ -38,6 +37,12 @@ from .SSHQueue import stopSSHQueue
 from .OutputThread import stopOutputThread
 
 from .Generic import Password
+
+# map the debug_level choices to the python logging levels
+DEBUG_LEVEL = { 'err': logging.ERROR,
+                'warn': logging.WARNING,
+                'info': logging.INFO,
+                'debug': logging.DEBUG}
 
 def _parse_hostfile(host):
     keys = ['host', 'username', 'password']
@@ -116,6 +121,10 @@ def create_argument():
     parser.add_argument("-O", "--output-format", dest="output_format",
         choices=['csv', 'json'], default="csv",
         help="Ouptut format")
+    parser.add_argument("--debug", dest="debug_level",
+        choices=['err', 'warn', 'info', 'debug'], default="warn",
+        help="Level of debug messages, defaults to [warn]")
+
 
     # we use a default of "-" for the -C/ssh-config option to differentiate from None
     #    -        = -C not provided, eventually set it to None
@@ -131,6 +140,9 @@ def create_argument():
         help='Commands')
 
     options = parser.parse_args()
+
+    logging.basicConfig(level=DEBUG_LEVEL[options.debug_level])
+
     if options.hostfile:
         options.hosts = options.hostfile.read()
     elif options.stdin:
@@ -184,6 +196,7 @@ def create_argument():
     # if it's "-", set it to None
     if options.sshconfig is None:
         options.sshconfig = f"/home/{options.username}/.ssh/config"
+        print(f"using default ssh-config file: {options.sshconfig}")
     elif options.sshconfig == '-':
         options.sshconfig = None
 

--- a/sshpt/sshpt.py
+++ b/sshpt/sshpt.py
@@ -23,7 +23,6 @@
 # TODO:  Add stderr handling
 # TODO:  Add ability to specify the ownership and permissions of uploaded files (when sudo is used)
 # TODO:  Add logging using the standard module
-# TODO:  Supports Python3
 
 # Docstring:
 """
@@ -85,7 +84,6 @@ class SSHPowerTool(object):
             while self.ssh_connect_queue.qsize() > self.options.max_threads:
                 sleep(0.1)
 
-#            if self.ssh_connect_queue.qsize() <= self.options.max_threads:
             if self.options.passwordless:
                 password = None
             else:

--- a/sshpt/sshpt.py
+++ b/sshpt/sshpt.py
@@ -29,7 +29,7 @@
 """
 SSH Power Tool (SSHPT): This program will attempt to login via SSH to a list of servers supplied in a text file (one host per line).  It supports multithreading and will perform simultaneous connection attempts to save time (10 by default).  Results are output to stdout in CSV format and optionally, to an outfile (-o).
 If no username and/or password are provided as command line arguments or via a credentials file the program will prompt for the username and password to use in the connection attempts.
-This program is meant for situations where shared keys are not an option.  If all your hosts are configured with shared keys for passwordless logins you don't need the SSH Power Tool.
+This program is meant for situations where shared keys are not an option.  If all your hosts are configured with shared keys for passwordless logins use the -X/--passwordless argument for RSA keys.
 """
 
 
@@ -39,6 +39,14 @@ import sys
 
 from time import sleep
 import logging
+
+try:
+    import paramiko
+    logging.getLogger("paramiko").setLevel(logging.WARNING)
+except ImportError:
+    print("ERROR: The Paramiko module required to use sshpt.")
+    print("Download it here: http://www.lag.net/paramiko/")
+    sys.exit(1)
 
 # Import Internal
 from .OutputThread import startOutputThread, stopOutputThread
@@ -66,12 +74,26 @@ class SSHPowerTool(object):
             # Assume we're just doing a connection test
             self.options.commands = ['echo CONNECTION TEST', ]
 
+        if self.options.sshconfig:
+            ssh_config = paramiko.SSHConfig()
+            ssh_config.parse(open(self.options.sshconfig))
+        else:
+            ssh_config = None
+
+
         for host in self.options.hosts:
             if self.ssh_connect_queue.qsize() <= self.options.max_threads:
                 if self.options.passwordless:
                     password = None
                 else:
                     password = host.get('password', self.options.password).password,
+
+                if ssh_config:
+                    host_lookup = ssh_config.lookup(host['host'])
+                    if host_lookup['hostname'] != host['host']:
+                        logger.debug("found hostname in ssh config file: substituing %s for %s",
+                                     host_lookup['hostname'], host['host'])
+                        host['host'] = host_lookup['hostname']
 
                 queueObj = dict(
                     host=host.get('host'),


### PR DESCRIPTION
added -C / --sshconfig option.  If provided without a value it defaults to /home/<username>/.ssh/config

modified -k / --keyfile to default to /home/<username>/.ssh/id_rsa if a value is not provided

When the --sshconfig option is provided, the respective ssh config file is used to lookup
hostnames.  If a match is found and differs from host['host'] it replaces host['host'].

Example usage of recent changes:

sshpt -C /tmp/ssh-cfg -f /tmp/file -k  -X  "echo foo"

sshpt -C -f /tmp/file  -k  -X  "echo foo"

sshpt -C -f /tmp/file -k /home/foo/.ssh/id_rsa -X "echo foo"

